### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   node-tests:
     name: Node.js Tests


### PR DESCRIPTION
Potential fix for [https://github.com/Sindhu-2222/my-blog-practice/security/code-scanning/2](https://github.com/Sindhu-2222/my-blog-practice/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary read access to the repository contents, which is sufficient for the current workflow. If any job requires additional permissions in the future, they can be defined specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
